### PR TITLE
Add optional sort key for glossary entries to handle diacritics

### DIFF
--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -53,6 +53,7 @@
   // Return the normalized entry
   (
     short: entry.short,
+    sort: entry.at("sort", default: entry.short),
     plural: entry.at("plural", default: __pluralize(entry.short)),
     article: entry.at("article", default: __determine_article(entry.short)),
     long: long,
@@ -204,6 +205,7 @@
 //     - "pl": Use plural form of the term.
 //     - "both": Show "Long form (short form)".
 //     - "short": Show only the short form.
+//     - "sort": the valued used for sorting the term in the glossary
 //     - "long": Show only the long form.
 //     - "def" or "desc": Show the term's description instead of its name.
 //     - "a" or "an": Prepend an article, chosen from the entry (short or long form).
@@ -669,6 +671,7 @@
       if entry.at("group") == group {
         current_entries.push((
           short: entry.at("short"),
+          sort: entry.at("sort", default: entry.at("short")),
           long: entry.at("long"),
           description: entry.at("description"),
           label: [#metadata(key)#__entry_label(key)],
@@ -685,7 +688,7 @@
       let sorted_entries = if sort {
         current_entries
           // 1. create array of tuples with (lower [if ignore-case], entry)
-          .map(e => { if ignore-case { (lower(e.short), e) } else { (e.short, e) } })
+          .map(e => { if ignore-case { (lower(e.sort), e) } else { (e.sort, e) } })
           // 2. sort the tuples (by first element then second)
           .sorted() // NOTE: sorted() is NOT language-aware
           // 3. strip away the tuple's first element, leaving an array of entries

--- a/tests/sorting/test.typ
+++ b/tests/sorting/test.typ
@@ -24,6 +24,11 @@
     long: "test procedure specification",
     description: "A document on how to run all the test procedures"
   ),
+  cegep: (
+    short: "CÉGEP",
+    sort: "CEGEP",
+    long: "Collège d’enseignement général et professionnel",
+  ),
 )
 
 #show: init-glossary.with(myGlossary, show-term: (body) => [#emph(body)])
@@ -31,7 +36,7 @@
 #set page(numbering: "1")
 
 = Refer to our terms so they show up in the glossary
-@html, @iphone:long, @css, @css:cap:pl, @atom:pl, @tps:long
+@html, @iphone:long, @css, @css:cap:pl, @atom:pl, @tps:long, @cegep
 
 = Default sorting
 #glossary(theme: theme-compact)


### PR DESCRIPTION
Hello,

I’d like to propose adding an optional `sort` key to the glossary to give users explicit control over how glossary entries are ordered.

This is particularly useful to avoid incorrect sorting caused by diacritics. For example, I added a common Quebec acronym (**CÉGEP**), where we would want the `É` to be treated as an `E` for sorting purposes.

I’ve updated the tests to ensure this behaviour works as expected. While this key would be optional, it provides a practical solution for advanced sorting needs until proper Unicode normalization becomes available in Typst.

I’m happy to make additional changes to the documentation if you think that would be helpful. Please let me know if you’d like me to adapt or refine this solution further.

Thanks for the awesome project!

### Demo:
<img width="861" height="573" alt="image" src="https://github.com/user-attachments/assets/d2a52ba9-bf2a-4a9d-8455-db220f04218f" />
