### PR TITLE
chore: add just. Update README_publish.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
     "vscode": {
       "extensions": [
         "bierner.markdown-mermaid",
+        "mhutchie.git-graph",
         "myriad-dreamin.tinymist",
         "nvarner.typst-lsp"
       ]

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 TYPST_VERSION="0.14.2"
 TYTANIC_VERSION="0.3.3"
-WATCHEXEC_VERSION="2.5.1"
 TYPSTYLE_VERSION="0.14.4"
+JUST_VERSION="1.40.0"
+WATCHEXEC_VERSION="2.5.1"
 
 ARCH="$(uname -m)"
 case "$ARCH" in
@@ -37,5 +38,22 @@ curl -fsSL "https://github.com/typstyle-rs/typstyle/releases/download/v${TYPSTYL
   -o "$tmp_typstyle"
 sudo install -m 0755 "$tmp_typstyle" /usr/local/bin/typstyle
 rm -f "$tmp_typstyle"
+
+tmp_just="$(mktemp)"
+curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${T}.tar.gz" \
+  | tar -xOz just > "$tmp_just"
+sudo install -m 0755 "$tmp_just" /usr/local/bin/just
+rm -f "$tmp_just"
+
+watchexec_url="https://github.com/watchexec/watchexec/releases/download/v${WATCHEXEC_VERSION}/watchexec-${WATCHEXEC_VERSION}-${T}.tar.xz"
+tmp_watchexec="$(mktemp)"
+curl -fsSL "$watchexec_url" \
+  | tar -xJOf - --wildcards "*/watchexec" > "$tmp_watchexec"
+sudo install -m 0755 "$tmp_watchexec" /usr/local/bin/watchexec
+rm -f "$tmp_watchexec"
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends ripgrep python3
+sudo rm -rf /var/lib/apt/lists/*
 
 echo "*** Container build successfully ***"

--- a/README_publish.md
+++ b/README_publish.md
@@ -5,39 +5,62 @@
 * repository to publish to: https://github.com/typst/packages/tree/main/packages/preview/glossy
 
 * doc: https://github.com/typst/packages/blob/main/docs/README.md
+* doc: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude
 
 Example PR from glossy:
 
 - [v0.9.0](https://github.com/typst/packages/pull/3323)
 - [v0.8.0](https://github.com/typst/packages/pull/2122)
 
-## Prepare to push upstream
+## Prepare to publish
+
+**There is a branch `submitted-upstream`: It will no longer be used for publishing.**
 
 1. Make these commands run without error
 
     ```bash
-    # Format files in place
-    typstyle -i .
-
-    # Testrunner
-    tt run --no-fail-fast
+    just fmt    # format all .typ files in place
+    just check  # fmt-check + full test suite
     ```
 
 2. Update changelog in `README.md`
 
 3. Update version in `typst.toml`
 
-4. Commit to `main`
+   ```bash
+   just bump patch # or minor
+   ```
 
-5. Manage branches
+4. Run full pre-submission checks
 
-   a. If `submitted-upstream` has commits not in `main`, merge `submitted-upstream` into `main`.
+   ```bash
+   just pre-submit  # clean → images → check
+   ```
 
-   b. Merge `main` into `submitted-upstream`.
-      Both should now point to the same commit.
+5. Commit to `main` and create a version tag.
 
-   c. Create version tag.
+   ```bash
+   git tag -a vx.y.z -m "x.y.z"
+   git push && git push --tags
+   ```
 
-   d. Create PR from `submitted-upstream` to https://github.com/typst/packages
+6. Copy package files into a local clone of the upstream registry.
 
-6. If PR was merged and `submitted-upstream` has commits not in `main`, merge `submitted-upstream` into `main`.
+   ```bash
+   cd ~/src/glossy
+   TYPST_PACKAGES_REPO=~/typst-packages
+
+   ver=$(grep '^version' "typst.toml" | cut -d'"' -f2)
+   dest="$TYPST_PACKAGES_REPO/packages/preview/glossy/$ver"
+
+   rm -r "$dest"
+   mkdir -p "$dest"
+   cp -r src "$dest/"
+   cp -r justfile lib.typ LICENSE README.md typst.toml themeshots.png thumbnail.png "$dest/"
+   ```
+
+   Then commit and open a PR from the typst/packages clone (see example PRs above).
+
+## Notes on just
+
+Run `just` (or `just help`) to list all available recipes.

--- a/glossy.code-workspace
+++ b/glossy.code-workspace
@@ -21,6 +21,7 @@
 	"extensions": {
 		"recommendations": [
 			"bierner.markdown-mermaid",
+			"mhutchie.git-graph",
 			"myriad-dreamin.tinymist",
 			"nvarner.typst-lsp"
 		]

--- a/justfile
+++ b/justfile
@@ -9,11 +9,10 @@ TYPST := env_var_or_default("TYPST", "typst")
 TYPSTYLE := env_var_or_default("TYPSTYLE", "typstyle")
 
 # Paths
-THUMB_SRC := "tests/demo/test.typ"
 THUMB_OUT := "thumbnail.png"
 THEME_SRC := "tests/theme-gallery/test.typ"
 THEME_OUT := "themeshots.png"
-DEMO_SRC := "tests/demo/test.typ"
+DEMO_IMG := "tests/demo/out/1.png"
 DEMO_OUT := "build/demo.pdf"
 
 # Aliases
@@ -23,7 +22,8 @@ alias t := test
 alias w := watch
 
 # Default entrypoint
-[default]
+default: help
+
 help:
   @just --list --unsorted
 
@@ -69,14 +69,17 @@ watch *args:
 
 # ---------------------------- Artifacts ----------------------------
 
-# Build demo.typ -> demo.pdf
+# Build demo.pdf from the demo test output
 [group('artifacts')]
 demo:
+  {{TT}} run demo
   mkdir -p "$(dirname {{DEMO_OUT}})"
-  {{TYPST}} compile --root . {{DEMO_SRC}} {{DEMO_OUT}}
+  tmp="build/.demo-wrapper.typ"
+  printf '#set page(margin: 0pt)\n#image("../{{DEMO_IMG}}", width: 100%%)\n' > "$tmp"
+  {{TYPST}} compile --root . "$tmp" {{DEMO_OUT}}
+  rm -f "$tmp"
   @echo "Wrote {{DEMO_OUT}}"
 
-# Build all preview images
 # Build all preview images
 [group('artifacts')]
 images:


### PR DESCRIPTION
I discovered `justfile` in the repo.

Therefore I added  `just` and dependet tools to the devcontainer and tested the different `just` commands. `just demo` required fixes.

The README_publish.sh is pretty final now.